### PR TITLE
[WIP]groups/messages投稿画面へのajax実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,55 @@
+$(function(){
+  function addNewCommentToBottom(message){
+    let html = `
+    <div class="rightside__chatbox__partial">
+      <div class="rightside__chatbox__partial__wrapper">
+        <p class="rightside__chatbox__partial__wrapper--text">
+          ${message.user_name}
+        </p>
+        <p class="rightside__chatbox__partial__wrapper--date">
+          ${message.created_at}
+        </p>
+      </div>
+
+      <p class="rightside__chatbox__partial__message">
+          ${message.text}
+      </p>
+      <img class="rightside__chatbox__partial__image" src="${message.image}" alt="">
+    </div>
+    `;
+    return html;
+  }
+
+  function scrollToBottom(){
+    let long = $(".rightside__chatbox")[0].scrollHeight;
+    $(".rightside__chatbox").animate({scrollTop:long});
+  }
+
+  $("#new_message").on("submit",function(e){
+    e.preventDefault();
+    let formdata = new FormData(this);
+    let url      = $(this).attr("action");
+    console.log(url);
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formdata,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })    
+    .done(function(message){
+      let html = addNewCommentToBottom(message);
+      $(".rightside__chatbox").append(html);
+      $("#message_text").val("");
+      $("#message_image").val("");
+      scrollToBottom();
+    })
+    .fail(function () {
+      alert('ファイルの取得に失敗しました。');
+    })
+    .always(function(){
+      $(".rightside__messageform__submit").removeAttr("disabled");
+    })
+  })
+})

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load', function(){
   function addNewCommentToBottom(message){
     let html = `
     <div class="rightside__chatbox__partial">
@@ -29,7 +29,6 @@ $(function(){
     e.preventDefault();
     let formdata = new FormData(this);
     let url      = $(this).attr("action");
-    console.log(url);
     $.ajax({
       url: url,
       type: "POST",

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -41,8 +41,7 @@ $(function(){
     .done(function(message){
       let html = addNewCommentToBottom(message);
       $(".rightside__chatbox").append(html);
-      $("#message_text").val("");
-      $("#message_image").val("");
+      $("#new_message")[0].reset();
       scrollToBottom();
     })
     .fail(function () {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,7 +8,10 @@ before_action :set_group
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice:"メッセージを送信しました"
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice:"メッセージを送信しました"}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       @new_message = Message.new

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text         @message.text
+json.user_name    @message.user.name
+json.created_at   @message.created_at.in_time_zone('Tokyo').strftime("%Y-%m-%d%H:%M:%S")
+json.image        @message.image.url


### PR DESCRIPTION
# what
- メッセージフォームからの投稿を非同期通信とする
  - messagesコントローラにて、JSONのリクエストに対しjbuilderで生成したJSONを返す設定を追加
  - groups/[:group_id]/messages ビュー内のformで送信した際にformdataをJSON形式に変換してリクエストを行う仕様とする（messages.js）
  - 受信したJSONの値をもとにメッセージ一覧の最後尾にHTMLを追加し、最後尾までスクロールする

# why
- JSONでサーバとやりとりすることにより、投稿の度に画面を更新しないことでチャットの動作をより滑らかにするため