### PR TITLE
グループ編集画面でのインクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,64 @@
+$(document).on("turbolinks:load",function(){
+  
+  function showNameList(data){
+    let html =`
+          <div class="chat-group-user clearfix">
+            <p class="chat-group-user__name">${data.name}</p>
+            <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${data.user_id}" data-user-name="${data.name}">追加</div>
+          </div>`
+    $("#user-search-result").append(html);
+  }
+
+  function addNameList(data_user_id,data_user_name){
+    let html =`
+          <div class="chat-group-user clearfix">
+            <p class="chat-group-user__name">${data_user_name}</p>
+            <div class="user-search-add chat-group-user__btn chat-group-user__btn--remove" data-user-id="${data_user_id}" data-user-name:"${data_user_name}">削除</div>
+            <input type="hidden" value="${data_user_id}" checked="checked" name="group[user_ids][]" id="group_user_ids_${data_user_id}">
+          </div>`
+    $("#user-joined-in").append(html);
+  }
+
+  $("#user-search-field").on("keyup",function(){
+    let input = $(this).val();
+    $.ajax({
+        type: 'GET',
+        data: {keyword: input},
+        url: '/users#index',
+        dataType: 'json'
+      }).done(function(data){
+        $("#user-search-result").empty();
+        if (data.length !== 0) {
+          data.forEach(function(data){
+            showNameList(data);
+            })
+          $(".chat-group-user__btn--add").on("click",function(){
+            console.log(this);
+            let data_user_id    = $(this).attr("data-user-id");
+            let data_user_name  = $(this).attr("data-user-name");
+            addNameList(data_user_id,data_user_name);
+            $(this).parent().remove();
+            $("#user-search-field").val("");
+          })
+          $(".chat-group-user__btn--remove").on("click",function(){
+            console.log(this)
+            $(this).parent().remove();
+          })
+        }
+        else {
+          $("#user-search-result").append("一致するユーザはありません");
+        };
+      }).fail(function(){
+        alert("ユーザの取得に失敗しました")
+      })
+    });
+
+  $(".chat-group-user__btn--remove").on("click",function(){
+    console.log(this)
+    $(this).parent().remove();
+  });
+  
+})
+
+
+

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -17,6 +17,11 @@ $(document).on("turbolinks:load",function(){
             <input type="hidden" value="${data_user_id}" checked="checked" name="group[user_ids][]" id="group_user_ids_${data_user_id}">
           </div>`
     $("#user-joined-in").append(html);
+    $(".chat-group-user__btn--remove").on("click",function(){
+      console.log(this)
+      $(this).parent().remove();
+    });
+
   }
 
   $("#user-search-field").on("keyup",function(){
@@ -33,19 +38,13 @@ $(document).on("turbolinks:load",function(){
             showNameList(data);
             })
           $(".chat-group-user__btn--add").on("click",function(){
-            console.log(this);
             let data_user_id    = $(this).attr("data-user-id");
             let data_user_name  = $(this).attr("data-user-name");
             addNameList(data_user_id,data_user_name);
             $(this).parent().remove();
             $("#user-search-field").val("");
-          })
-          $(".chat-group-user__btn--remove").on("click",function(){
-            console.log(this)
-            $(this).parent().remove();
-          })
-        }
-        else {
+          });
+        } else {
           $("#user-search-result").append("一致するユーザはありません");
         };
       }).fail(function(){
@@ -54,10 +53,8 @@ $(document).on("turbolinks:load",function(){
     });
 
   $(".chat-group-user__btn--remove").on("click",function(){
-    console.log(this)
     $(this).parent().remove();
   });
-  
 })
 
 

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -18,7 +18,6 @@ $(document).on("turbolinks:load",function(){
           </div>`
     $("#user-joined-in").append(html);
     $(".chat-group-user__btn--remove").on("click",function(){
-      console.log(this)
       $(this).parent().remove();
     });
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 class UsersController < ApplicationController
   def index
     @results = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
-    p current_user.name
     respond_to do |format|
       format.json
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,14 @@
 class UsersController < ApplicationController
+  def index
+    @results = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.json
+    end
+  end
+
   def edit
   end
+
   def update
     if current_user.update(user_params)
       redirect_to root_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   def index
-    @results = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @results = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
+    p current_user.name
     respond_to do |format|
       format.json
     end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,34 @@
+= form_for @group do |f|
+  -if @group.errors.any?
+    .chat-group-form__errors
+      %h2="#{@group.errors.full_messages.count}件のエラーがあります"
+      %ul
+        -@group.errors.full_messages.each do |message|
+          %li="#{message}"
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label "グループ名", class: "chat-group-form__label"
+    .chat-group-form__field--right
+      = f.text_field :name, id: "chat_group_name", class:"chat-group-form__input",placeholder:"グループ名を入力してください"
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label{class:"chat-group-form__label" , for:"chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input{class: "chat-group-form__input", id:"user-search-field", placeholder:"追加したいユーザー名を入力してください", type:"text"}
+      #user-search-result
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label "チャットメンバー", class:"chat-group-form__label"
+    .chat-group-form__field--right{id:"user-joined-in"}
+      %input{type:"hidden", name:"group[user_ids][]", value:""}
+        -@group.users.each do |user|
+          .chat-group-user.clearfix
+            %p{class:"chat-group-user__name"}
+              =user.name
+            .user-search-add.chat-group-user__btn.chat-group-user__btn--remove{"data-user-id": "#{user.id}","data-user-name": "#{user.name}"}削除
+            %input{type:"hidden", value:"#{user.id}", checked:"checked", name:"group[user_ids][]", id:"group_user_ids_#{user.id}"}
+  .chat-group-form__field
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class:"chat-group-form__action-btn"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,27 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  = form_for @group do |f|
-    -if @group.errors.any?
-      .chat-group-form__errors
-        %h2="#{@group.errors.full_messages.count}件のエラーがあります"
-        %ul
-          -@group.errors.full_messages.each do |message|
-            %li="#{message}"
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label "グループ名", class: "chat-group-form__label"
-      .chat-group-form__field--right
-        = f.text_field :name, id: "chat_group_name", class:"chat-group-form__input",placeholder:"グループ名を入力してください"
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class:"chat-group-form__label"
-      .chat-group-form__field--right
-        = f.collection_check_boxes :user_ids, User.all, :id, :name do |b|
-          = b.label { b.check_box + b.text }
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class:"chat-group-form__action-btn"
+  =render partial:"form", local:{group: @group}

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,27 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  =form_for @group do |f|
-    -if @group.errors.any?
-      .chat-group-form__errors
-        %h2="#{@group.errors.full_messages.count}件のエラーがあります"
-        %ul
-          -@group.errors.full_messages.each do |message|
-            %li="#{message}"
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label "グループ名" ,class: "chat-group-form__label"
-      .chat-group-form__field--right
-        = f.text_field :name ,id:"chat_group_name" ,class:"chat-group-form__input", placeholder: "グループ名を入力してください"
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class:"chat-group-form__label"
-      .chat-group-form__field--right
-        = f.collection_check_boxes :user_ids, User.all, :id, :name do |b|
-          = b.label { b.check_box + b.text }
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        =f.submit class:"chat-group-form__action-btn"
+  =render partial:"form"

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @results do |user|
+  json.name       user.name
+  json.user_id    user.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only:[:index,:new,:create,:edit,:update] do
     resources :messages,only: [:index,:create]
   end


### PR DESCRIPTION
# what
グループ編集/新規作成画面にて、
  - 追加したいユーザ名を逐次検索し、予測をリストにして出力する
  - 既存参加ユーザは「チャットメンバ」欄にリストとして記載する
    - （従来のチェックボックス式を廃止）
  - 予測リスト内「追加」ボタン、既存参加メンバ欄「削除」ボタンでメンバの追加・削除を可能とする
  - 「既に参加しているユーザが多重に登録できる（追加候補に表示される）」問題は未実装

# why
現状、チェックボックスに全登録ユーザを表示しているため、ユーザ登録数の増加に従って
  - 膨大なチェックボックスによりUIが崩れる
  - ユーザの追加のために該当欄をさがす労力がかかる
問題が浮上するため。